### PR TITLE
Tidying up types and thread safety, making 64bit work

### DIFF
--- a/Source/animation/NGLEase.m
+++ b/Source/animation/NGLEase.m
@@ -174,8 +174,8 @@ float nglEaseElasticIn(float begin, float change, float time, float duration)
 	{
 		return begin + change;
 	}
-	
-	return -x * powf(2.0f, 10.0f * --time) * sinf((time * duration - z) * kNGL_2PI / y) + begin;
+	--time;
+	return -x * powf(2.0f, 10.0f * time) * sinf((time * duration - z) * kNGL_2PI / y) + begin;
 }
 
 float nglEaseElasticInOut(float begin, float change, float time, float duration)

--- a/Source/core/NGLMesh.h
+++ b/Source/core/NGLMesh.h
@@ -321,11 +321,11 @@ NGL_API NSString *const kNGLMeshOriginalYes;
 	NGLmat4					_mvIMatrix;
 	
 	// Structure
-	unsigned int			*_indices;
+	UInt32                  *_indices;
 	float					*_structures;
-	unsigned int			_iCount;
-	unsigned int			_sCount;
-	unsigned int			_stride;
+	UInt32                  _iCount;
+	UInt32                  _sCount;
+	UInt32                  _stride;
 	NGLMeshElements			*_meshElements;
 	
 	// Properties
@@ -345,10 +345,10 @@ NGL_API NSString *const kNGLMeshOriginalYes;
 	// Delegate
 	id <NGLMeshDelegate>	_delegate;
 	Class					_delegateClass;
-	unsigned int			_inspector;
+	UInt32                  _inspector;
 	
 	// Helpers
-	unsigned int			_slot;
+	UInt32                  _slot;
 	NGLParsing				_parsing;
 	BOOL					_isParsing;
 	BOOL					_isCompiling;
@@ -389,23 +389,23 @@ NGL_API NSString *const kNGLMeshOriginalYes;
 /*!
  *					The array of indices's length.
  */
-@property (nonatomic, readonly) unsigned int indicesCount;
+@property (nonatomic, readonly) UInt32 indicesCount;
 
 /*!
  *					The array of structures's length.
  */
-@property (nonatomic, readonly) unsigned int structuresCount;
+@property (nonatomic, readonly) UInt32 structuresCount;
 
 /*!
  *					The array of structures's stride in computer basic units (bits).
  */
-@property (nonatomic, readonly) unsigned int stride;
+@property (nonatomic, readonly) UInt32 stride;
 
 /*!
  *					Pointer to the array of indices containing the instructions to work with OpenGL
  *					programmable pipeline.
  */
-@property (nonatomic, readonly) unsigned int *indices;
+@property (nonatomic, readonly) UInt32 *indices;
 
 /*!
  *					Pointer to the array of structures containing all the information about this
@@ -556,8 +556,8 @@ NGL_API NSString *const kNGLMeshOriginalYes;
 - (void) loadFile:(NSString *)named settings:(NSDictionary *)dict type:(NGL3DFileType)type;
 
 //- (void) loadMeshManually:(NSString *)named;
-//- (void) insertData:(float *)data count:(unsigned int)count type:(NGLComponent)component;
-//- (void) insertFaces:(unsigned int *)faces count:(unsigned int)count;
+//- (void) insertData:(float *)data count:(UInt32)count type:(NGLComponent)component;
+//- (void) insertFaces:(UInt32 *)faces count:(UInt32)count;
 
 /*!
  *					Stops the loading process. Cancelling the process is not immediately, it can
@@ -592,7 +592,7 @@ NGL_API NSString *const kNGLMeshOriginalYes;
  */
 - (void) drawMeshWithCamera:(NGLCamera *)camera;
 
-- (void) drawMeshWithCamera:(NGLCamera *)camera usingTelemetry:(unsigned int)telemetry;
+- (void) drawMeshWithCamera:(NGLCamera *)camera usingTelemetry:(UInt32)telemetry;
 
 /*!
  *					Sets the array of indices.
@@ -607,7 +607,7 @@ NGL_API NSString *const kNGLMeshOriginalYes;
  *					The array of indice's length. As the array of indices is a C array, you need to specify
  *					its length.
  */
-- (void) setIndices:(unsigned int *)newIndices count:(unsigned int)newCount;
+- (void) setIndices:(UInt32 *)newIndices count:(UInt32)newCount;
 
 /*!
  *					Sets the array of structures.
@@ -626,7 +626,7 @@ NGL_API NSString *const kNGLMeshOriginalYes;
  *					The array of structures's stride. This stride must be in elements, not basic
  *					machine units.
  */
-- (void) setStructures:(float *)newStructures count:(unsigned int)newCount stride:(unsigned int)newStride;
+- (void) setStructures:(float *)newStructures count:(UInt32)newCount stride:(UInt32)newStride;
 
 /*!
  *					<strong>(Internal only)</strong> You should not call this one manually.

--- a/Source/core/NGLMesh.m
+++ b/Source/core/NGLMesh.m
@@ -659,11 +659,12 @@ static void emptyCoreMesh(id <NGLCoreMesh> coreMesh)
 	// Performs the a method if the delegate target responds to the method.
 	if ((_inspector & check))
 	{
+        // AH: Really need a language upgrade to use ARC and weak references
+        // to deal with potentially deallocated threads on async main dispatch.
         __weak NGLMesh *weakSelf = self;
 		dispatch_async(dispatch_get_main_queue(), ^(void)
 		{
             NGLMesh *safeSelf = weakSelf;
-//            [safeSelf.delegate performSelector:selector withObject:safeSelf.parsing];
             if( safeSelf ){
                 ((id (*)(id, SEL, NGLParsing))objc_msgSend)(safeSelf.delegate, selector, safeSelf.parsing);
             }

--- a/Source/core/NGLMesh.m
+++ b/Source/core/NGLMesh.m
@@ -83,7 +83,7 @@ NSString *const kNGLMeshOriginalYes = @"useOriginalYes";
 //**************************************************
 
 // Global thread slots to the loading.
-static unsigned int *_slots = NULL;
+static UInt32 *_slots = NULL;
 
 // Global pointer library to the meshes.
 static NGLArray *_meshes;
@@ -128,10 +128,10 @@ static NGL3DFileType fileTypeForFile(NSString *fileNamed)
 }
 
 // Choose the best thread slot at this time. The best thread will be the one with less pending job.
-static unsigned int parseSlot(void)
+static UInt32 parseSlot(void)
 {
 	int i;
-	unsigned int min, index;
+	UInt32 min, index;
 	
 	// Initialize the slots once, setting all items to 0.
 	if (_slots == NULL)
@@ -156,7 +156,7 @@ static unsigned int parseSlot(void)
 }
 
 // Frees one number in a specific slot.
-static void parseFreeSlot(unsigned int slot)
+static void parseFreeSlot(UInt32 slot)
 {
 	--slot;
 	
@@ -424,7 +424,7 @@ static void emptyCoreMesh(id <NGLCoreMesh> coreMesh)
 
 - (void) defineBoundingBox
 {
-	unsigned int i, n;
+	UInt32 i, n;
 	float vx, vy, vz;
 	NGLvec3 vMin, vMax;
 	unsigned char vertexStart = (*[_meshElements elementWithComponent:NGLComponentVertex]).start;
@@ -581,7 +581,7 @@ static void emptyCoreMesh(id <NGLCoreMesh> coreMesh)
 - (void) parserNotification:(NGLMeshInspector)action
 {
 	SEL selector;
-	unsigned int check = NGLMeshNone;
+	UInt32 check = NGLMeshNone;
 	
 	// Avoids unecessary processes.
 	if (_inspector == NGLMeshNone)
@@ -659,17 +659,14 @@ static void emptyCoreMesh(id <NGLCoreMesh> coreMesh)
 	// Performs the a method if the delegate target responds to the method.
 	if ((_inspector & check))
 	{
+        __weak NGLMesh *weakSelf = self;
 		dispatch_async(dispatch_get_main_queue(), ^(void)
 		{
-			// Avoids invalid or released delegate.
-			if (nglPointerIsValidToClass(_delegate, _delegateClass))
-			{
-				((id (*)(id, SEL, NGLParsing))objc_msgSend)(_delegate, selector, _parsing);
-			}
-			else
-			{
-				_inspector = NGLMeshNone;
-			}
+            NGLMesh *safeSelf = weakSelf;
+//            [safeSelf.delegate performSelector:selector withObject:safeSelf.parsing];
+            if( safeSelf ){
+                ((id (*)(id, SEL, NGLParsing))objc_msgSend)(safeSelf.delegate, selector, safeSelf.parsing);
+            }
 		});
 	}
 }
@@ -843,7 +840,7 @@ static void emptyCoreMesh(id <NGLCoreMesh> coreMesh)
 		_slot = parseSlot();
 		
 		// Starts or queue this load in the selected parser tread. The Parser Thread is a short-lived one.
-		NSString *threadName = [NSString stringWithFormat:@"%@-%i", kNGLThreadParser, _slot];
+		NSString *threadName = [NSString stringWithFormat:@"%@-%i", kNGLThreadParser, (unsigned int)_slot];
 		nglThreadPerformAsync(threadName, @selector(loadFile), self);
 	}
 }
@@ -918,7 +915,7 @@ static void emptyCoreMesh(id <NGLCoreMesh> coreMesh)
 	}
 }
 
-- (void) drawMeshWithCamera:(NGLCamera *)camera usingTelemetry:(unsigned int)telemetry
+- (void) drawMeshWithCamera:(NGLCamera *)camera usingTelemetry:(UInt32)telemetry
 {
 	// Avoids to render a mesh while the upload is not ready yet.
 	if (_coreMesh.isReady)
@@ -933,18 +930,20 @@ static void emptyCoreMesh(id <NGLCoreMesh> coreMesh)
 	}
 }
 
-- (void) setIndices:(unsigned int *)newIndices count:(unsigned int)newCount
+- (void) setIndices:(UInt32 *)newIndices count:(UInt32)newCount
 {
 	// Copies the memory of array of indices.
 	_indices = realloc(_indices, newCount * NGL_SIZE_UINT);
+    NSAssert(_indices != NULL, @"Invalid Indices reallocation");
 	memcpy(_indices, newIndices, newCount * NGL_SIZE_UINT);
 	_iCount = newCount;
 }
 
-- (void) setStructures:(float *)newStructures count:(unsigned int)newCount stride:(unsigned int)newStride
+- (void) setStructures:(float *)newStructures count:(UInt32)newCount stride:(UInt32)newStride
 {
 	// Copies the memory of array of structures.
 	_structures = realloc(_structures, newCount * NGL_SIZE_FLOAT);
+    NSAssert(_structures != NULL, @"Invalid Structures reallocation");
 	memcpy(_structures, newStructures, newCount * NGL_SIZE_FLOAT);
 	_sCount = newCount;
 	_stride = newStride;
@@ -1026,7 +1025,7 @@ static void emptyCoreMesh(id <NGLCoreMesh> coreMesh)
 	else
 	{
 		// Starts or queue this load in the selected parser tread.
-		NSString *name = [NSString stringWithFormat:@"%@-%i", kNGLThreadParser, _slot];
+		NSString *name = [NSString stringWithFormat:@"%@-%i", kNGLThreadParser, (unsigned int)_slot];
 		nglThreadPerformAsync(name, @selector(invoke), invocation);
 	}
 }

--- a/Source/core/NGLRuntime.h
+++ b/Source/core/NGLRuntime.h
@@ -142,7 +142,7 @@
 #define NGL_SAMPLER_CUBE	0x11
 
 // Size of basic data types
-#define NGL_SIZE_POINTER	4
+#define NGL_SIZE_POINTER	sizeof(void*)
 #define NGL_SIZE_FLOAT		4
 #define NGL_SIZE_INT		4
 #define NGL_SIZE_UINT		4

--- a/Source/core/NGLThread.m
+++ b/Source/core/NGLThread.m
@@ -211,8 +211,9 @@ void nglThreadPerformSync(NSString *name, SEL selector, id target)
 {
 	// Creates the thread once, if necessary.
 	NGLThread *thread = nglThreadGet(name);
-	
-    NSLog(@"%@ performSync: %@", name, NSStringFromSelector(selector));
+
+// AH: Watch the syncrhonous thread execution, debugging in case of thread deadlocking.
+//    NSLog(@"%@ performSync: %@", name, NSStringFromSelector(selector));
 	[thread performSync:selector target:target];
 }
 
@@ -291,9 +292,6 @@ void nglThreadExitAll(void)
 		
 		// Only the render thread is a long-lived one.
 		_autoExit = (!([name isEqualToString:kNGLThreadRender]||[name isEqualToString:kNGLThreadHelper]));
-        if( [name isEqualToString:@"NinevehGLHelper"] ) {
-            NSLog(@"Helper alloc..");
-        }
 		
 		// The threads are internally retained to make future changes on it.
 		[threads() setObject:self forKey:_name];
@@ -361,19 +359,6 @@ void nglThreadExitAll(void)
             // Defines one task done.
             oneTaskDone = YES;
         }
-
-// First-in First-out rule. The first item will be detached, so the iterator "doesn't move".
-//		nglFor(task, _queue)
-//		{
-//			// Executes the Obj-C message as fast as possible.
-//			[task execute];
-//			
-//			// Removes the first task.
-//			[_queue removeFirst];
-//			
-//			// Defines one task done.
-//			oneTaskDone = YES;
-//		}
 		
 		// Draining the pool.
 		nglRelease(pool);
@@ -489,12 +474,6 @@ void nglThreadExitAll(void)
 
 - (void) dealloc
 {
-	// Doesn't need to exit the NGLThread because the dealloc can't be called while the thread is alive.
-    NSLog(@"Dealloc thread: %@", _name);
-    if( [_name isEqualToString:@"NinevehGLHelper"] ) {
-        NSLog(@"Helper dealloc!!");
-    }
-    
 	nglRelease(_name);
 	nglRelease(_queue);
 	nglRelease(_thread);

--- a/Source/core/NGLView.h
+++ b/Source/core/NGLView.h
@@ -175,13 +175,13 @@
  *					Gets the current OpenGL framebuffer for this NGLView. It's useful to work with third
  *					party libraries that ask you for the framebuffer reference.
  */
-@property (nonatomic, readonly) unsigned int framebuffer;
+@property (nonatomic, readonly) UInt32 framebuffer;
 
 /*!
  *					Gets the current OpenGL renderbuffer (color) for this NGLView. It's useful to work with
  *					third party libraries that ask you for the renderbuffer reference.
  */
-@property (nonatomic, readonly) unsigned int renderbuffer;
+@property (nonatomic, readonly) UInt32 renderbuffer;
 
 /*!
  *					A pointer to the background color. This color is a NinevehGL color (NGLvec4).

--- a/Source/core/NGLView.m
+++ b/Source/core/NGLView.m
@@ -242,9 +242,9 @@ static void emptyCoreEngine(id <NGLCoreEngine> coreEngine, BOOL background)
 	}
 }
 
-- (unsigned int) framebuffer { return _engine.framebuffer; }
+- (UInt32) framebuffer { return _engine.framebuffer; }
 
-- (unsigned int) renderbuffer { return _engine.renderbuffer; }
+- (UInt32) renderbuffer { return _engine.renderbuffer; }
 
 - (NGLvec4 *) colorPointer { return &_color; }
 
@@ -573,7 +573,11 @@ static void emptyCoreEngine(id <NGLCoreEngine> coreEngine, BOOL background)
 	// Releases the collection if it becomes empty.
 	if ([_views count] == 0)
 	{
+        // Exit all threads: render, parsing, and helper.
+        nglThreadExitAll();
+
 		nglRelease(_views);
+//        nglThreadExit(kNGLThreadRender);
 	}
 	
     [super dealloc];

--- a/Source/effects/NGLSurface.h
+++ b/Source/effects/NGLSurface.h
@@ -74,25 +74,25 @@
 @interface NGLSurface : NSObject <NGLSurface>
 {
 @private
-	unsigned int			_identifier;
-	unsigned int			_startData;
-	unsigned int			_lengthData;
+	UInt32			_identifier;
+	UInt32			_startData;
+	UInt32			_lengthData;
 }
 
 /*!
  *					The identifier of this object.
  */
-@property (nonatomic) unsigned int identifier;
+@property (nonatomic) UInt32 identifier;
 
 /*!
  *					Represents the starting index inside of this surface on the mesh's array of indices.
  */
-@property (nonatomic) unsigned int startData;
+@property (nonatomic) UInt32 startData;
 
 /*!
  *					Represents the length, in elements, of this surface on the mesh's array of indices.
  */
-@property (nonatomic) unsigned int lengthData;
+@property (nonatomic) UInt32 lengthData;
 
 /*!
  *					Initiates a new instance with a start data, length data and an identifier.
@@ -108,7 +108,7 @@
  *
  *	@result			A new initialized instance.
  */
-- (id) initWithStart:(unsigned int)start length:(unsigned int)length identifier:(unsigned int)newId;
+- (id) initWithStart:(UInt32)start length:(UInt32)length identifier:(UInt32)newId;
 
 /*!
  *					Returns an autorelease instance of NGLSurface.
@@ -136,6 +136,6 @@
  *
  *	@result			A NGLSurface autoreleased instance.
  */
-+ (id) surfacetWithStart:(unsigned int)start length:(unsigned int)length identifier:(unsigned int)newId;
++ (id) surfacetWithStart:(UInt32)start length:(UInt32)length identifier:(UInt32)newId;
 
 @end

--- a/Source/effects/NGLSurface.m
+++ b/Source/effects/NGLSurface.m
@@ -89,7 +89,7 @@
 	return self;
 }
 
-- (id) initWithStart:(unsigned int)start length:(unsigned int)length identifier:(unsigned int)newId
+- (id) initWithStart:(UInt32)start length:(UInt32)length identifier:(UInt32)newId
 {
 	if ((self = [super init]))
 	{
@@ -110,7 +110,7 @@
 	return [newSurface autorelease];
 }
 
-+ (id) surfacetWithStart:(unsigned int)start length:(unsigned int)length identifier:(unsigned int)newId
++ (id) surfacetWithStart:(UInt32)start length:(UInt32)length identifier:(UInt32)newId
 {
 	NGLSurface *newSurface = [[NGLSurface alloc] initWithStart:start length:length identifier:newId];
 	
@@ -179,9 +179,9 @@
 			Start: %i\n\
 			Length: %i\n",
 			[super description],
-			self.identifier,
-			self.startData,
-			self.lengthData];
+			(unsigned int)self.identifier,
+			(unsigned int)self.startData,
+			(unsigned int)self.lengthData];
 }
 
 @end

--- a/Source/effects/NGLSurfaceMulti.h
+++ b/Source/effects/NGLSurfaceMulti.h
@@ -131,7 +131,7 @@
  *
  *	@see			NGLSurface
  */
-- (NGLSurface *) surfaceWithIdentifier:(unsigned int)identifier;
+- (NGLSurface *) surfaceWithIdentifier:(UInt32)identifier;
 
 /*!
  *					Returns a surface by its index.
@@ -150,14 +150,14 @@
  *
  *	@see			NGLSurface
  */
-- (NGLSurface *) surfaceAtIndex:(unsigned int)index;
+- (NGLSurface *) surfaceAtIndex:(UInt32)index;
 
 /*!
  *					Returns the number of instances in this library at the moment.
  *
- *	@result			An unsigned int data type.
+ *	@result			An UInt32 data type.
  */
-- (unsigned int) count;
+- (UInt32) count;
 
 /*!
  *					Returns an autorelease instance of NGLSurfaceMulti.

--- a/Source/effects/NGLSurfaceMulti.m
+++ b/Source/effects/NGLSurfaceMulti.m
@@ -229,7 +229,7 @@
 	[_collection removeAll];
 }
 
-- (NGLSurface *) surfaceWithIdentifier:(unsigned int)identifier
+- (NGLSurface *) surfaceWithIdentifier:(UInt32)identifier
 {
 	NGLSurface *item = nil;
 	
@@ -244,12 +244,12 @@
 	return item;
 }
 
-- (NGLSurface *) surfaceAtIndex:(unsigned int)index
+- (NGLSurface *) surfaceAtIndex:(UInt32)index
 {
 	return [_collection pointerAtIndex:index];
 }
 
-- (unsigned int) count
+- (UInt32) count
 {
 	return [_collection count];
 }
@@ -268,7 +268,7 @@
 								   objects:(NGL_ARC_ASSIGN id *)stackbuf
 									 count:(NSUInteger)len
 {
-	unsigned int count = [_collection count];
+	UInt32 count = [_collection count];
 	
     if ((*state).state >= count)
     {

--- a/Source/es2/NGLES2Mesh.m
+++ b/Source/es2/NGLES2Mesh.m
@@ -117,13 +117,13 @@
 	// TODO remove all this shit when iOS 6 comes out.
 	//*
 	void *indices;
-	unsigned int dataSize;
-	unsigned short *newData = NULL;
+	UInt32 dataSize;
+	UInt16 *newData = NULL;
 	
 	if (nglDeviceSystemVersion() < NGL_IOS_5_0)
 	{
-		unsigned int *data = _parent.indices;
-		unsigned int count = _parent.indicesCount;
+		UInt32 *data = _parent.indices;
+		UInt32 count = _parent.indicesCount;
 		
 		if (count > NGL_MAX_16)
 		{
@@ -136,11 +136,11 @@
 		
 		newData = malloc(count * NGL_SIZE_USHORT);
 		
-		unsigned int i;
-		unsigned int length = count;
+		UInt32 i;
+		UInt32 length = count;
 		for (i = 0; i < length; ++i)
 		{
-			newData[i] = (unsigned short)data[i];
+			newData[i] = (UInt16)data[i];
 		}
 		
 		indices = newData;
@@ -206,7 +206,7 @@
 	NGLSurfaceMulti *sufLib;
 	
 	NGLSurface *surface;
-	unsigned short sufId;
+	UInt16 sufId;
 	BOOL multiMtl = [_parent.material isKindOfClass:[NGLMaterialMulti class]];
 	BOOL multiShd = [_parent.shaders isKindOfClass:[NGLShadersMulti class]];
 	
@@ -284,7 +284,7 @@
 	[_buffers bind];
 	
 	NGLES2Polygon *polygon;
-	nglFor (polygon, _polygons)
+    nglFor (polygon, _polygons)
 	{
 		[polygon drawPolygon];
 	}
@@ -293,7 +293,7 @@
 	[_buffers unbind];
 }
 
-- (void) drawTelemetry:(unsigned int)telemetry
+- (void) drawTelemetry:(UInt32)telemetry
 {
 	NGLvec4 color = nglTelemetryIDToColor(telemetry);
 	

--- a/Source/es2/NGLES2Polygon.m
+++ b/Source/es2/NGLES2Polygon.m
@@ -197,7 +197,7 @@ static void setDynamicVariables(NGLSLVariables *variables, BOOL activate)
 	//*/
 	
 	// Adjusts the surface.
-	_start = (void *)(unsigned long)(surface.startData * _dataTypeSize);
+	_start = (void *)(UInt64)(surface.startData * _dataTypeSize); // FIXME: What is going on with this address calculation??
 	_length = surface.lengthData;
 	
 	// Sets the default material.
@@ -294,7 +294,7 @@ static void setDynamicVariables(NGLSLVariables *variables, BOOL activate)
 					[_textures addTexture:(NGLTexture *)(*variable).data];
 					
 					// Replaces the NGLTexture reference by the final texture unit to this texture object.
-					(*variable).data = (void *)(unsigned long)[_textures getLastUnit];
+					(*variable).data = (void *)(UInt64)[_textures getLastUnit];
 					break;
 			}
 		}

--- a/Source/es2/NGLES2Program.m
+++ b/Source/es2/NGLES2Program.m
@@ -91,6 +91,14 @@ static GLuint _currentProgram;
 //	Constructors
 //**************************************************
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _name = 0;
+    }
+    return self;
+}
 
 #pragma mark -
 #pragma mark Private Methods

--- a/Source/es2/NGLES2Textures.m
+++ b/Source/es2/NGLES2Textures.m
@@ -110,7 +110,8 @@ static void nglRemoveTexturesFromCache(int *count, GLuint *values)
 		if (value == 0)
 		{
 			[_tCacheMMC removeObjectForKey:key];
-			values = realloc(values, sizeof(GLuint) * (newCount + 1));
+// AH FIXME: Problems with realloc and AddressSanitizer, so disabling reducing the texture cache size for now.
+//			values = realloc(values, sizeof(GLuint) * (newCount + 1));
 			values[newCount] = copy[i];
 			++newCount;
 		}

--- a/Source/math/NGLVector.h
+++ b/Source/math/NGLVector.h
@@ -82,7 +82,7 @@ NGL_API NGLvec4 nglColorFromRGBA(unsigned short r, unsigned short g, unsigned sh
  *
  *	@result			A NGLvec4 with the desired color.
  */
-NGL_API NGLvec4 nglColorFromHexadecimal(unsigned int hex);
+NGL_API NGLvec4 nglColorFromHexadecimal(UInt32 hex);
 
 /*!
  *					This function generates a color based on an CGColorRef, it must be in RGB color space.
@@ -122,7 +122,7 @@ NGL_API UIColor *nglColorToUIColor(NGLvec4 color);
  *
  *	@result			A color in hexadecimal notation for RGBA (0xNNNNNNNN).
  */
-NGL_API unsigned int nglColorToHexadecimal(NGLvec4 color);
+NGL_API UInt32 nglColorToHexadecimal(NGLvec4 color);
 
 /*!
  *					Checks if the color is not a black one.
@@ -158,7 +158,7 @@ NGL_API BOOL nglColorIsNotBlack(NGLvec4 color);
  *
  *	@result			A NGLvec4 representing the color for this telemetry ID.
  */
-NGL_API NGLvec4 nglTelemetryIDToColor(unsigned int telemetryID);
+NGL_API NGLvec4 nglTelemetryIDToColor(UInt32 telemetryID);
 
 /*!
  *					Converts a RGBA color into telemetry ID.
@@ -168,9 +168,9 @@ NGL_API NGLvec4 nglTelemetryIDToColor(unsigned int telemetryID);
  *	@param			rgba
  *					A NGLivec4 with the RGBA color.
  *
- *	@result			An unsigned int with the extracted telemetry ID.
+ *	@result			An UInt32 with the extracted telemetry ID.
  */
-NGL_API unsigned int nglTelemetryIDFromRGBA(NGLivec4 rgba);
+NGL_API UInt32 nglTelemetryIDFromRGBA(NGLivec4 rgba);
 
 /*!
  *					Converts a color (NGLvec4) into telemetry ID.
@@ -180,9 +180,9 @@ NGL_API unsigned int nglTelemetryIDFromRGBA(NGLivec4 rgba);
  *	@param			color
  *					A NGLvec4 with the color.
  *
- *	@result			An unsigned int with the extracted telemetry ID.
+ *	@result			An UInt32 with the extracted telemetry ID.
  */
-NGL_API unsigned int nglTelemetryIDFromColor(NGLvec4 color);
+NGL_API UInt32 nglTelemetryIDFromColor(NGLvec4 color);
 
 #pragma mark -
 #pragma mark Vec2 Functions

--- a/Source/math/NGLVector.m
+++ b/Source/math/NGLVector.m
@@ -54,7 +54,7 @@ NGLvec4 nglColorFromRGBA(unsigned short r, unsigned short g, unsigned short b, u
 	return nglColorMake((float)r / 255.0f, (float)g / 255.0f, (float)b / 255.0f, (float)a / 255.0f);
 }
 
-NGLvec4 nglColorFromHexadecimal(unsigned int hex)
+NGLvec4 nglColorFromHexadecimal(UInt32 hex)
 {
 	return nglColorFromRGBA((hex >> 24) & 0xFF, (hex >> 16) & 0xFF, (hex >> 8) & 0xFF, (hex >> 0) & 0xFF);
 }
@@ -95,7 +95,7 @@ UIColor *nglColorToUIColor(NGLvec4 color)
 	return [UIColor colorWithRed:color.r green:color.g blue:color.b alpha:color.a];
 }
 
-unsigned int nglColorToHexadecimal(NGLvec4 color)
+UInt32 nglColorToHexadecimal(NGLvec4 color)
 {
 	NGLivec4 rgba = (NGLivec4){ color.r * 255.0f, color.g * 255.0f, color.b * 255.0f, color.a * 255.0f };
 	
@@ -113,17 +113,17 @@ BOOL nglColorIsNotBlack(NGLvec4 color)
 //	Telemetry Functions
 //**************************************************
 
-NGLvec4 nglTelemetryIDToColor(unsigned int telemetryID)
+NGLvec4 nglTelemetryIDToColor(UInt32 telemetryID)
 {
 	return (NGLvec4){ (telemetryID >> 8 & 0xFF) / 255.0f, (telemetryID & 0xFF) / 255.0f, 0.0f, 1.0f };
 }
 
-unsigned int nglTelemetryIDFromRGBA(NGLivec4 rgba)
+UInt32 nglTelemetryIDFromRGBA(NGLivec4 rgba)
 {
 	return (rgba.r << 8) + rgba.g;
 }
 
-unsigned int nglTelemetryIDFromColor(NGLvec4 color)
+UInt32 nglTelemetryIDFromColor(NGLvec4 color)
 {
 	return nglTelemetryIDFromRGBA((NGLivec4){ color.r * 255.0f, color.g * 255.0f, color.b, color.a });
 }

--- a/Source/parser/NGLParserDAE.m
+++ b/Source/parser/NGLParserDAE.m
@@ -714,7 +714,7 @@ static void daeSetString(NSString **target, NSString *newString)
 
 - (void) defineFaceTo:(int)index
 {
-	unsigned int *faces;
+	UInt32 *faces;
 	NGLivec3 vGroup;
 	
 	_faces = realloc(_faces, NGL_SIZE_INT * (++_facesCount * _facesStride));

--- a/Source/parser/NGLParserMTL.h
+++ b/Source/parser/NGLParserMTL.h
@@ -54,7 +54,7 @@
 {
 @private
 	// Helpers
-	unsigned int			_lines;
+	UInt32			_lines;
 	NSString				*_finalPath;
 	NSMutableArray			*_files;
 	NSArray					*_cuted;

--- a/Source/parser/NGLParserMTL.m
+++ b/Source/parser/NGLParserMTL.m
@@ -67,7 +67,7 @@ static NSString *const REG_FILE_PATH = @"\\W*?\\w+? (.*)";
 //**************************************************
 
 // Global count to the materials created by this parse.
-static unsigned int _mtlCount;
+static UInt32 _mtlCount;
 
 #pragma mark -
 #pragma mark Private Category
@@ -155,7 +155,7 @@ static unsigned int _mtlCount;
 	}
 	else
 	{
-		_error.message = [NSString stringWithFormat:MTL_IMCOMPLETE_VALUES, _lines];
+		_error.message = [NSString stringWithFormat:MTL_IMCOMPLETE_VALUES, (unsigned int)_lines];
 	}
 	
 	return color;
@@ -233,10 +233,10 @@ static unsigned int _mtlCount;
 		_currentMaterial.alpha = 1;
 		
 		float alpha = 0.0f;
-		unsigned int n = 0;
+		UInt32 n = 0;
 		
-		unsigned int i;
-		unsigned int length = _cutedCount;
+		UInt32 i;
+		UInt32 length = _cutedCount;
 		
 		for (i = 1; i < length; i++)
 		{
@@ -405,7 +405,7 @@ static unsigned int _mtlCount;
 	// Checks if file exist.
 	if (source == nil)
 	{
-		_error.message = [NSString stringWithFormat:MTL_NOT_FOUND, _lines];
+		_error.message = [NSString stringWithFormat:MTL_NOT_FOUND, (unsigned int)_lines];
 	}
 	
 	// Prints error if exist.

--- a/Source/parser/NGLParserMesh.h
+++ b/Source/parser/NGLParserMesh.h
@@ -95,11 +95,11 @@
 {
 @protected
 	// Structure Components
-	unsigned int			_vCount;
-	unsigned int			_tCount;
-	unsigned int			_nCount;
-	unsigned int			_taCount;
-	unsigned int			_biCount;
+	UInt32                  _vCount;
+	UInt32                  _tCount;
+	UInt32                  _nCount;
+	UInt32                  _taCount;
+	UInt32                  _biCount;
 	float					*_vertices;
 	float					*_texcoords;
 	float					*_normals;
@@ -107,15 +107,15 @@
 	float					*_bitangents;
 	
 	// Faces
-	unsigned int			_facesCount;
-	unsigned int			_facesStride;
-	unsigned int			*_faces;
+	UInt32                  _facesCount;
+	UInt32                  _facesStride;
+	UInt32                  *_faces;
 	
 	// Data
-	unsigned int			_iCount;
-	unsigned int			_sCount;
-	unsigned int			_stride;
-	unsigned int			*_indices;
+	UInt32                  _iCount;
+	UInt32                  _sCount;
+	UInt32                  _stride;
+	UInt32                  *_indices;
 	float					*_structures;
 	
 	// Mesh Structure
@@ -161,24 +161,24 @@
 /*!
  *					The number of elements in the array of indices.
  */
-@property (nonatomic, readonly) unsigned int indicesCount;
+@property (nonatomic, readonly) UInt32 indicesCount;
 
 /*!
  *					The number of elements in the array of structures.
  */
-@property (nonatomic, readonly) unsigned int structuresCount;
+@property (nonatomic, readonly) UInt32 structuresCount;
 
 /*!
  *					The stride of elements in the array of structures. This stride is given in elements.
  *					However, OpenGL needs stride in basic machine units (bytes). So this number must be
  *					converted later on, before be sent to OpenGL's core.
  */
-@property (nonatomic, readonly) unsigned int stride;
+@property (nonatomic, readonly) UInt32 stride;
 
 /*!
- *					The array of indices. It's an unsigned int data type.
+ *					The array of indices. It's an UInt32 data type.
  */
-@property (nonatomic, readonly) unsigned int *indices;
+@property (nonatomic, readonly) UInt32 *indices;
 
 /*!
  *					The array of structures. It's composed by float data type because OpenGL

--- a/Source/parser/NGLParserMesh.m
+++ b/Source/parser/NGLParserMesh.m
@@ -62,10 +62,10 @@ The number of unique faces in your file should not exceed it.";
 
 // Checks the crease angle for the normal calculations.
 // This function creates and divides the normals to a vertex recursively.
-static unsigned int creaseAngle(unsigned int index,
+static UInt32 creaseAngle(UInt32 index,
 								NGLvec3 vector,
 								NGLvec3 **buffer,
-								unsigned int *count,
+								UInt32 *count,
 								NSMutableDictionary *list)
 {
 	NSNumber *newIndex, *oldIndex;
@@ -323,11 +323,11 @@ static unsigned int creaseAngle(unsigned int index,
 
 - (void) defineTangentSpace
 {
-	unsigned int i, length;
-	unsigned int j, lengthJ;
+	UInt32 i, length;
+	UInt32 j, lengthJ;
 	
-	unsigned int *newFaces, *outFaces;
-	unsigned int oldFaceStride = _facesStride;
+	UInt32 *newFaces, *outFaces;
+	UInt32 oldFaceStride = _facesStride;
 	
 	int i1, i2, i3;
 	int vi1, vi2, vi3;
@@ -648,16 +648,16 @@ static unsigned int creaseAngle(unsigned int index,
 
 - (void) defineStructure
 {
-	unsigned int i, lengthI;
-	unsigned int j, lengthJ;
-	unsigned int index, faceIndex;
+	UInt32 i, lengthI;
+	UInt32 j, lengthJ;
+	UInt32 index, faceIndex;
 	
 	NGLElement *element;
-	unsigned int eIndex, eStart;
+	UInt32 eIndex, eStart;
 	float *eValue;
 	
 	float *outStructure;
-	unsigned int *outIndex;
+	UInt32 *outIndex;
 	
 	char *faceData;
 	char *faceCString;
@@ -706,7 +706,7 @@ static unsigned int creaseAngle(unsigned int index,
 		// To avoid that, it's necessary to add a slash: 11/1 and 1/11 is now different.
 		while ((element = [_meshElements nextIterator]))
 		{
-			sprintf(faceData, "%i/", _faces[faceIndex + (*element).offsetInFace]);
+			sprintf(faceData, "%i/", (unsigned int)_faces[faceIndex + (*element).offsetInFace]);
 			strcat(faceCString, faceData);
 		}
 		
@@ -719,7 +719,7 @@ static unsigned int creaseAngle(unsigned int index,
 		if (indexNum == nil)
 		{
 			// Adds the new face string.
-			index = (unsigned int)[faceProcessed count];
+			index = (UInt32)[faceProcessed count];
 			[faceProcessed setObject:[NSNumber numberWithUnsignedInt:index] forKey:faceString];
 			
 			// Reallocates the array of structures and sets a pointer to the following process.

--- a/Source/parser/NGLParserNGL.h
+++ b/Source/parser/NGLParserNGL.h
@@ -73,21 +73,21 @@
  *
  *					|--- 4 bytes (float)            NGL Binary file version
  *					|
- *					|--- 4 bytes (unsigned int)     Count - Elements Node
+ *					|--- 4 bytes (UInt32)     Count - Elements Node
  *					|   |
  *					|   |--- 1 byte (unsigned char)     component
  *					|   |--- 1 byte (unsigned char)     start
  *					|   |--- 1 byte (unsigned char)     length
  *					|   |--- 1 byte (unsigned char)     offsetInFace
  *					|
- *					|--- 4 bytes (unsigned int)     Count - Indices
- *					|--- 4 bytes (unsigned int)     Count - Structures
- *					|--- 4 bytes (unsigned int)     Stride
+ *					|--- 4 bytes (UInt32)     Count - Indices
+ *					|--- 4 bytes (UInt32)     Count - Structures
+ *					|--- 4 bytes (UInt32)     Stride
  *					|
  *					|--- x bytes (unsigned short)   Indices array
  *					|--- x bytes (float)            Structure array
  *					|
- *					|--- 4 bytes (unsigned int)     Count - Materials Node
+ *					|--- 4 bytes (UInt32)     Count - Materials Node
  *					|   |
  *					|   |--- 2 bytes (unsigned short)   Identifier
  *					|   |--- 2 bytes (unsigned short)   Name length
@@ -103,7 +103,7 @@
  *					|   |--- 4 bytes (float)            Shininess
  *					|   |--- 4 bytes (float)            Refraction
  *					|   |
- *					|   |--- 4 bytes (unsigned int)     Count - Texture Node
+ *					|   |--- 4 bytes (UInt32)     Count - Texture Node
  *					|           |
  *					|           |--- 2 bytes (unsigned short)   Map kind (alpha, ambient, diffuse, ...)
  *					|           |--- 2 bytes (unsigned short)   Name length
@@ -114,12 +114,12 @@
  *					|           |--- 1 byte (unsigned char)     Repeat
  *					|           |--- 1 byte (unsigned char)     Optimize
  *					|
- *					|--- 4 bytes (unsigned int)     Count - Surface Node
+ *					|--- 4 bytes (UInt32)     Count - Surface Node
  *					    |
  *					    |--- 2 bytes (unsigned short)   Identifier
  *					    |          
- *					    |--- 4 bytes (unsigned int)     Start data
- *					    |--- 4 bytes (unsigned int)     Length data
+ *					    |--- 4 bytes (UInt32)     Start data
+ *					    |--- 4 bytes (UInt32)     Length data
  *
  *					</pre>
  *	
@@ -130,7 +130,7 @@
 {
 @private
 	// Helpers
-	unsigned int			_rangeIndex;
+	UInt32			_rangeIndex;
 }
 
 /*!

--- a/Source/parser/NGLParserNGL.m
+++ b/Source/parser/NGLParserNGL.m
@@ -80,22 +80,22 @@ typedef enum
 } NGLMapType;
 
 // NGLMesh structure.
-// 12 bytes: 3 unsigned int.
+// 12 bytes: 3 UInt32.
 typedef struct
 {
-	unsigned int	indicesCount;
-	unsigned int	structuresCount;
-	unsigned int	stride;
+	UInt32	indicesCount;
+	UInt32	structuresCount;
+	UInt32	stride;
 } NGLMeshBody;
 
 // NGLMeshElement structure.
-// 4 bytes: 4 unsigned char.
+// 4 bytes: 4 UInt8.
 typedef struct
 {
-	unsigned char		component;
-	unsigned char		start;
-	unsigned char		length;
-	unsigned char		offsetInFace;
+	UInt8		component;
+	UInt8		start;
+	UInt8		length;
+	UInt8		offsetInFace;
 } NGLElementBody;
 
 // NGLMaterial structure.
@@ -116,18 +116,18 @@ typedef struct
 // 4 bytes: 4 char.
 typedef struct
 {
-	unsigned char	type;
-	unsigned char	quality;
-	unsigned char	repeat;
-	unsigned char	optimize;
+	UInt8	type;
+	UInt8	quality;
+	UInt8	repeat;
+	UInt8	optimize;
 } NGLMapBody;
 
 // NGLSurface structure.
-// 8 bytes: 2 unsigned int.
+// 8 bytes: 2 UInt32.
 typedef struct
 {
-	unsigned int	startData;
-	unsigned int	lengthData;
+	UInt32	startData;
+	UInt32	lengthData;
 } NGLSurfaceBody;
 
 // Full path to the NinevehGL binary folder in the Library directory.
@@ -145,7 +145,7 @@ static NSString		*_nglPath;
 - (void) resetRange;
 
 // Increments and returns a new locator/pointer to work on the bit stream.
-- (NSRange) rangeUntil:(unsigned int)length;
+- (NSRange) rangeUntil:(UInt32)length;
 
 // Extracts the data from a NGL Binary file.
 - (void) extractDataFromFile:(NSString *)fullPath;
@@ -220,7 +220,7 @@ static NSString		*_nglPath;
 	_totalParsedData = 1;
 }
 
-- (NSRange) rangeUntil:(unsigned int)length
+- (NSRange) rangeUntil:(UInt32)length
 {
 	NSRange range = (NSRange){_rangeIndex,length};
 	_rangeIndex += length;
@@ -234,7 +234,7 @@ static NSString		*_nglPath;
 - (void) extractDataFromFile:(NSString *)fullPath
 {
 	NSData *data = nglDataFromFile(fullPath);
-	unsigned int i, j;
+	UInt32 i, j;
 	
 	// Resets the helpers.
 	[self resetRange];
@@ -265,7 +265,7 @@ static NSString		*_nglPath;
 	//*************************
 	
 	// Basic body properties.
-	unsigned int elementCount;
+	UInt32 elementCount;
 	NGLElementBody elementBody;
 	NGLElement element;
 	NGLMeshBody meshBody;
@@ -316,13 +316,13 @@ static NSString		*_nglPath;
 	char *name;
 	
 	// Materials.
-	unsigned int materialsCount;
-	unsigned int materialID;
+	UInt32 materialsCount;
+	UInt32 materialID;
 	NGLMaterial *material;
 	NGLMaterialBody materialBody;
 	
 	// Textures.
-	unsigned int  mapsCount;
+	UInt32  mapsCount;
 	unsigned short mapKind;
 	NGLTexture *map;
 	NGLMapBody mapBody;
@@ -435,8 +435,8 @@ static NSString		*_nglPath;
 	//*************************
 	
 	// Surfaces.
-	unsigned int surfacesCount;
-	unsigned int surfaceID;
+	UInt32 surfacesCount;
+	UInt32 surfaceID;
 	NGLSurface *surface;
 	NGLSurfaceBody surfaceBody;
 	
@@ -486,7 +486,7 @@ static NSString		*_nglPath;
 	//*************************
 	
 	// Basic body properties.
-	unsigned int elementCount;
+	UInt32 elementCount;
 	NGLElementBody elementBody;
 	NGLElement *element;
 	NGLMeshBody meshBody;
@@ -534,13 +534,13 @@ static NSString		*_nglPath;
 	char *name;
 	
 	// Materials.
-	unsigned int materialsCount;
-	unsigned int materialID;
+	UInt32 materialsCount;
+	UInt32 materialID;
 	NGLMaterial *material;
 	NGLMaterialBody materialBody;
 	
 	// Textures.
-	unsigned int mapsCount;
+	UInt32 mapsCount;
 	unsigned short mapKind;
 	NGLTexture *map;
 	NGLMapBody mapBody;
@@ -665,8 +665,8 @@ static NSString		*_nglPath;
 	NGLSurfaceMulti		*sufLib = parse.surface;
 	
 	// Surfaces.
-	unsigned int surfacesCount;
-	unsigned int surfaceID;
+	UInt32 surfacesCount;
+	UInt32 surfaceID;
 	NGLSurface *surface;
 	NGLSurfaceBody surfaceBody;
 	

--- a/Source/parser/NGLParserOBJ.h
+++ b/Source/parser/NGLParserOBJ.h
@@ -86,7 +86,7 @@
 {
 @private
 	// Helpers
-	unsigned int			_lines;
+	UInt32			_lines;
 	NSString				*_finalPath;
 	NSMutableDictionary		*_faceStore;
 	NSArray					*_cuted;
@@ -99,7 +99,7 @@
 	// Groups
 	NGLivec3				*_groups;
 	int						_gCount;
-	unsigned int			_currentGrp;
+	UInt32			_currentGrp;
 
 	// Materials
 	NGLParserMTL			*_mtlParser;

--- a/Source/parser/NGLParserOBJ.m
+++ b/Source/parser/NGLParserOBJ.m
@@ -190,7 +190,7 @@ static NGLivec3 objFaceToVector(const char *cFace)
 
 - (void) processFace:(NSString *)face
 {
-	unsigned int *faces;
+	UInt32 *faces;
 	NGLivec3 vFace, vGroup;
 	
 	_faces = realloc(_faces, (++_facesCount * _facesStride) * NGL_SIZE_INT);
@@ -243,8 +243,8 @@ static NGLivec3 objFaceToVector(const char *cFace)
 	//*************************
 	if (strcmp(_prefix, "f") == 0)
 	{
-		unsigned int i;
-		unsigned int length = (_cutedCount > 4) ? _cutedCount : 4;
+		UInt32 i;
+		UInt32 length = (_cutedCount > 4) ? _cutedCount : 4;
 		for (i = 1; i < length; i++)
 		{
 			// If the current face forms a polygon which has more than 3 vertices,
@@ -268,7 +268,7 @@ static NGLivec3 objFaceToVector(const char *cFace)
 		// Checks for number of values.
 		if (_cutedCount <= 2)
 		{
-			_error.message = [NSString stringWithFormat:OBJ_ERROR_IMCOMPLETE_VALUES, _lines];
+			_error.message = [NSString stringWithFormat:OBJ_ERROR_IMCOMPLETE_VALUES, (unsigned int)_lines];
 			return;
 		}
 		
@@ -286,7 +286,7 @@ static NGLivec3 objFaceToVector(const char *cFace)
 		// Checks for number of values.
 		if (_cutedCount <= 3)
 		{
-			_error.message = [NSString stringWithFormat:OBJ_ERROR_IMCOMPLETE_VALUES, _lines];
+			_error.message = [NSString stringWithFormat:OBJ_ERROR_IMCOMPLETE_VALUES, (unsigned int)_lines];
 			return;
 		}
 		
@@ -306,7 +306,7 @@ static NGLivec3 objFaceToVector(const char *cFace)
 		// Checks for number of values.
 		if (_cutedCount <= 3)
 		{
-			_error.message = [NSString stringWithFormat:OBJ_ERROR_IMCOMPLETE_VALUES, _lines];
+			_error.message = [NSString stringWithFormat:OBJ_ERROR_IMCOMPLETE_VALUES, (unsigned int)_lines];
 			return;
 		}
 		
@@ -333,7 +333,7 @@ static NGLivec3 objFaceToVector(const char *cFace)
 		// Checks for multiple materials.
 		if (_cutedCount > 2)
 		{
-			_error.message = [NSString stringWithFormat:OBJ_ERROR_MULTIPLE_MTL, _lines];
+			_error.message = [NSString stringWithFormat:OBJ_ERROR_MULTIPLE_MTL, (unsigned int)_lines];
 		}
 		
 		// Mark the material to be used in a specific place into array of indices.
@@ -346,8 +346,8 @@ static NGLivec3 objFaceToVector(const char *cFace)
 	{
 		NSMutableString *fullName = [[NSMutableString alloc] init];
 		
-		unsigned int i;
-		unsigned int length = _cutedCount;
+		UInt32 i;
+		UInt32 length = _cutedCount;
 		for (i = 1; i < length; i++)
 		{
 			[fullName appendString:[_cuted objectAtIndex:i]];
@@ -433,13 +433,13 @@ static NGLivec3 objFaceToVector(const char *cFace)
 	//  Checks for faces count.
 	if (_facesCount == 0)
 	{
-		_error.message = [NSString stringWithFormat:OBJ_ERROR_NO_FACES, _lines];
+		_error.message = [NSString stringWithFormat:OBJ_ERROR_NO_FACES, (unsigned int)_lines];
 	}
 	
 	// Checks if the file exists.
 	if (source == nil)
 	{
-		_error.message = [NSString stringWithFormat:OBJ_ERROR_NO_FILE, _lines];
+		_error.message = [NSString stringWithFormat:OBJ_ERROR_NO_FILE, (unsigned int)_lines];
 	}
 	
 	// Defines the structure if no error was found, otherwise shows the error.

--- a/Source/shader/NGLSLConstructor.m
+++ b/Source/shader/NGLSLConstructor.m
@@ -933,7 +933,7 @@ void nglConstructShaders(NGLShaders *shaders, NGLMaterial *material, NGLMesh *me
 		variable = ATT_TANGENT;
 		variable.stride = stride;
 		variable.count = (*element).length;
-		variable.data = (void *)(unsigned long)((*element).start * NGL_SIZE_FLOAT);
+		variable.data = (void *)(UInt64)((*element).start * NGL_SIZE_FLOAT);
 		[shaders.variables addVariable:variable];
 		
 		element = [elements elementWithComponent:NGLComponentBitangent];
@@ -941,7 +941,7 @@ void nglConstructShaders(NGLShaders *shaders, NGLMaterial *material, NGLMesh *me
 		variable = ATT_BITANGENT;
 		variable.stride = stride;
 		variable.count = (*element).length;
-		variable.data = (void *)(unsigned long)((*element).start * NGL_SIZE_FLOAT);
+		variable.data = (void *)(UInt64)((*element).start * NGL_SIZE_FLOAT);
 		[shaders.variables addVariable:variable];
 		
 		addShaderElement(VSH_TANGENT, shaders.vertex);
@@ -1006,7 +1006,7 @@ void nglConstructShaders(NGLShaders *shaders, NGLMaterial *material, NGLMesh *me
 		variable = ATT_NORMAL;
 		variable.stride = stride;
 		variable.count = (*element).length;
-		variable.data = (void *)(unsigned long)((*element).start * NGL_SIZE_FLOAT);
+		variable.data = (void *)(UInt64)((*element).start * NGL_SIZE_FLOAT);
 		[shaders.variables addVariable:variable];
 		
 		addShaderElement(VSH_NORMAL, shaders.vertex);
@@ -1028,7 +1028,7 @@ void nglConstructShaders(NGLShaders *shaders, NGLMaterial *material, NGLMesh *me
 		variable = ATT_MAP;
 		variable.stride = stride;
 		variable.count = (*element).length;
-		variable.data = (void *)(unsigned long)((*element).start * NGL_SIZE_FLOAT);
+		variable.data = (void *)(UInt64)((*element).start * NGL_SIZE_FLOAT);
 		[shaders.variables addVariable:variable];
 		
 		addShaderElement(VSH_MAP, shaders.vertex);
@@ -1049,7 +1049,7 @@ void nglConstructShaders(NGLShaders *shaders, NGLMaterial *material, NGLMesh *me
 	variable = ATT_VERTEX;
 	variable.stride = stride;
 	variable.count = (*element).length;
-	variable.data = (void *)(unsigned long)((*element).start * NGL_SIZE_FLOAT);
+	variable.data = (void *)(UInt64)((*element).start * NGL_SIZE_FLOAT);
 	[shaders.variables addVariable:variable];
 	
 	// The base FSH and VSH will always exist.

--- a/Source/shader/NGLSLVariables.h
+++ b/Source/shader/NGLSLVariables.h
@@ -83,10 +83,10 @@ typedef struct
 {
 	BOOL isDynamic;
 	NGL_ARC_ASSIGN NSString *name;
-	unsigned int location;
+	UInt32 location;
 	unsigned char count; // 128 max Uniform in VSH
 	unsigned char dataType; // 3 data types: float, bool and int
-	unsigned int stride;
+	UInt32 stride;
 	void *data;
 	void *glFunction;
 } NGLSLVariable;
@@ -202,8 +202,8 @@ typedef struct
 /*!
  *					Returns the number of instances in this library at the moment.
  *
- *	@result			An unsigned int data type.
+ *	@result			An UInt32 data type.
  */
-- (unsigned int) count;
+- (UInt32) count;
 
 @end

--- a/Source/shader/NGLSLVariables.m
+++ b/Source/shader/NGLSLVariables.m
@@ -122,8 +122,8 @@
 
 - (NGLSLVariable *) variableWithName:(NSString *)name
 {
-	unsigned int i;
-	unsigned int length = _vCount;
+	UInt32 i;
+	UInt32 length = _vCount;
 	for (i = 0; i < length; i++)
 	{
 		if ([name isEqualToString:_variables[i].name])
@@ -140,8 +140,8 @@
 	NGLSLVariable variable;
 	NGLSLVariable *variables = _variables;
 	
-	unsigned int i;
-	unsigned int length = _vCount;
+	UInt32 i;
+	UInt32 length = _vCount;
 	for (i = 0; i < length; i++)
 	{
 		variable = _variables[i];
@@ -165,8 +165,8 @@
 {
 	NGLSLVariable variable;
 	
-	unsigned int i;
-	unsigned int length = _vCount;
+	UInt32 i;
+	UInt32 length = _vCount;
 	for (i = 0; i < length; i++)
 	{
 		variable = _variables[i];
@@ -180,7 +180,7 @@
 	nglFree(_variables);
 }
 
-- (unsigned int) count
+- (UInt32) count
 {
 	return _vCount;
 }

--- a/Source/utils/NGLArray.h
+++ b/Source/utils/NGLArray.h
@@ -26,6 +26,12 @@
 
 #import <pthread.h>
 
+// AH: Thread contention debugging is an incredibly tricky task,
+//  this #define adds some mutex lock counting and callstack recording
+//  functionality to help with diagnosing where another thread had the lock first.
+
+// #define  NGLARRAY_THREAD_CONTENTION_DEBUG
+
 /*!
  *					<strong>(Internal only)</strong> An object that holds the array values.
  *
@@ -56,9 +62,11 @@ typedef struct
 	void			**iterator;
 	unsigned int	i;
     pthread_mutex_t mutex; // AH: Adding thread safety to all NGLArray operations.
+#ifdef NGLARRAY_THREAD_CONTENTION_DEBUG
     unsigned int    mutex_lock_count;
     NSString        *callthread;
     NSArray<NSString*> *callstack;
+#endif
 } NGLArrayValues;
 
 /*!

--- a/Source/utils/NGLArray.h
+++ b/Source/utils/NGLArray.h
@@ -24,6 +24,8 @@
 #import "NGLError.h"
 #import "NGLIterator.h"
 
+#import <pthread.h>
+
 /*!
  *					<strong>(Internal only)</strong> An object that holds the array values.
  *
@@ -53,6 +55,10 @@ typedef struct
 	BOOL			retainOption;
 	void			**iterator;
 	unsigned int	i;
+    pthread_mutex_t mutex; // AH: Adding thread safety to all NGLArray operations.
+    unsigned int    mutex_lock_count;
+    NSString        *callthread;
+    NSArray<NSString*> *callstack;
 } NGLArrayValues;
 
 /*!
@@ -80,9 +86,8 @@ typedef struct
  *					The NGLArray instance to loop through.
  */
 #define nglFor(p, a)\
-for(NGLArrayValues *v = [(((a) != nil) ? (a) : [NGLArray array]) forLoop:(void **)&(p)];\
-(*v).i < (*v).count;\
-(*v).i++, (p) = *(*v).iterator++)
+for([a forLoop:(void **)&(p)]; [a forCheck]; p = [a nextIterator])
+//(*v).i++, (p) = ((*v).i+1 < (*v).count) ? *(*v).iterator++ : [(((a) != nil) ? (a) : [NGLArray array]) endLoop] )
 
 /*!
  *					Checks if a pointer is valid or not, that means, if a pointer is really pointing to
@@ -407,6 +412,17 @@ NGL_API BOOL nglPointerIsValidToSelector(void *pointer, SEL selector);
 - (unsigned int) count;
 
 /*!
+ *                  Lock a critical section so array manipulations on other threads are synchronized.
+ */
+- (void) lock;
+
+/*!
+ *                  Unlock a critical section
+ */
+- (void) unlock;
+ 
+
+/*!
  *					<strong>(Internal only)</strong> Prepares this array to work with "nglFor" loop.
  *					You should not call this method directly.
  *
@@ -417,6 +433,31 @@ NGL_API BOOL nglPointerIsValidToSelector(void *pointer, SEL selector);
  *	@result			A pointer to the values of this array.
  */
 - (NGLArrayValues *) forLoop:(void **)target;
+
+/*!
+ *					<strong>(Internal only)</strong> Checks the "nglFor" loop for additional iterations,
+ *                  otherwise terminates and unlocks the iterator.
+ *					You should not call this method directly.
+ *
+ *	@result			Returns YES if next iteration possible.
+ */
+- (BOOL) forCheck;
+
+/*!
+ *					<strong>(Internal only)</strong> Iterates the "nglFor" loop.
+ *					You should not call this method directly.
+ *
+ *	@result			Returns next object or NULL if past last object.
+ */
+- (void *) nextIterator;
+
+/*!
+ *					<strong>(Internal only)</strong> Finishes the last "nglFor" loop iteration of this array.
+ *					You should not call this method directly.
+ *
+ *	@result			Always return NULL
+ */
+- (void *) endLoop;
 
 /*!
  *					Returns an autoreleased instance of NGLArray.

--- a/Source/utils/NGLArray.h
+++ b/Source/utils/NGLArray.h
@@ -87,7 +87,6 @@ typedef struct
  */
 #define nglFor(p, a)\
 for([a forLoop:(void **)&(p)]; [a forCheck]; p = [a nextIterator])
-//(*v).i++, (p) = ((*v).i+1 < (*v).count) ? *(*v).iterator++ : [(((a) != nil) ? (a) : [NGLArray array]) endLoop] )
 
 /*!
  *					Checks if a pointer is valid or not, that means, if a pointer is really pointing to
@@ -425,6 +424,7 @@ NGL_API BOOL nglPointerIsValidToSelector(void *pointer, SEL selector);
 /*!
  *					<strong>(Internal only)</strong> Prepares this array to work with "nglFor" loop.
  *					You should not call this method directly.
+ *                  Locks the array mutex.
  *
  *	@param			target
  *					A pointer to the target that will receive the items of this array. Inside this
@@ -438,6 +438,7 @@ NGL_API BOOL nglPointerIsValidToSelector(void *pointer, SEL selector);
  *					<strong>(Internal only)</strong> Checks the "nglFor" loop for additional iterations,
  *                  otherwise terminates and unlocks the iterator.
  *					You should not call this method directly.
+ *                  Last iteration unlocks the array mutex.
  *
  *	@result			Returns YES if next iteration possible.
  */
@@ -450,14 +451,6 @@ NGL_API BOOL nglPointerIsValidToSelector(void *pointer, SEL selector);
  *	@result			Returns next object or NULL if past last object.
  */
 - (void *) nextIterator;
-
-/*!
- *					<strong>(Internal only)</strong> Finishes the last "nglFor" loop iteration of this array.
- *					You should not call this method directly.
- *
- *	@result			Always return NULL
- */
-- (void *) endLoop;
 
 /*!
  *					Returns an autoreleased instance of NGLArray.

--- a/Source/utils/NGLArray.m
+++ b/Source/utils/NGLArray.m
@@ -649,9 +649,12 @@ BOOL nglPointerIsValidToSelector(void *pointer, SEL selector)
     pthread_mutexattr_init(&attr);
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
     pthread_mutex_init(&_values.mutex, &attr );
+    
+#ifdef NGLARRAY_THREAD_CONTENTION_DEBUG
     _values.mutex_lock_count=0;
     _values.callstack=nil;
     _values.callthread = nil;
+#endif
 
     nglArrayResize(&_values);
 }

--- a/Source/utils/NGLArray.m
+++ b/Source/utils/NGLArray.m
@@ -67,6 +67,45 @@ static Class *classesList = NULL;
 //	Private Functions
 //**************************************************
 
+static void nglArrayLock(NGLArrayValues *array )
+{
+    int errvalue = pthread_mutex_trylock(&array->mutex);
+    if( errvalue != 0)  {
+        // EBUSY  = 16
+        // EINVAL = 24
+        NSLog(@"NGLArray Lock Contention");
+        pthread_mutex_lock(&array->mutex);
+    }
+    
+    array->mutex_lock_count++;
+    if( array->callstack ) {
+        [array->callstack release];
+    }
+    array->callstack = [[NSThread callStackSymbols] retain];
+    array->callthread = [NSThread currentThread].name;
+}
+
+static void nglArrayUnlock(NGLArrayValues *array )
+{
+    if( array->mutex_lock_count == 0 ) {
+        NSLog(@"Too many unlocks");
+    }
+    
+    array->mutex_lock_count--;
+    
+    // Last unlock releases the callstack.
+    if (array->mutex_lock_count == 0 ) {
+        if( array->callstack ) {
+            [array->callstack release];
+            array->callstack = nil;
+        }
+        
+        array->callthread = nil;
+    }
+
+    pthread_mutex_unlock(&array->mutex);
+}
+
 static void nglArrayResize(NGLArrayValues *array)
 {
 	/*
@@ -79,49 +118,61 @@ static void nglArrayResize(NGLArrayValues *array)
 	 *pointers = realloc(*pointers, NGL_SIZE_POINTER * *capacity);
 	 *iterator = *pointers + *i;
 	 /*/
+    nglArrayLock(array);
+    
 	(*array).capacity += kNGL_STRIDE_HINT;
 	(*array).pointers = realloc((*array).pointers, NGL_SIZE_POINTER * (*array).capacity);
 	(*array).iterator = (*array).pointers + (*array).i;
+
+    if( (*array).pointers == NULL ) {
+        NSLog( @"Error resizing array in glArrayResize(): %d = %s", errno, strerror(errno));
+    }
+
+    nglArrayUnlock(array);
 	//*/
 }
 
 static void nglArrayAddPointer(NGLArrayValues *array, void *pointer)
 {
-	if (pointer != NULL)
-	{
-		/*
-		 unsigned int *capacity = &(*array).capacity;
-		 unsigned int *count = &(*array).count;
-		 void ***pointers = &(*array).pointers;
-		 BOOL *retain = &(*array).retainOption;
-		 
-		 if (*count >= *capacity)
-		 {
-		 nglArrayResize(array);
-		 }
-		 
-		 if (*retain)
-		 {
-		 [(id)pointer retain];
-		 }
-		 
-		 (*pointers)[*count] = pointer;
-		 ++*count;
-		 /*/
-		if ((*array).count >= (*array).capacity)
-		{
-			nglArrayResize(array);
-		}
-		
-		if ((*array).retainOption)
-		{
-			[(id)pointer retain];
-		}
-		
-		(*array).pointers[(*array).count] = pointer;
-		++(*array).count;
-		//*/
-	}
+    if (pointer != NULL)
+    {
+        /*
+         unsigned int *capacity = &(*array).capacity;
+         unsigned int *count = &(*array).count;
+         void ***pointers = &(*array).pointers;
+         BOOL *retain = &(*array).retainOption;
+         
+         if (*count >= *capacity)
+         {
+         nglArrayResize(array);
+         }
+         
+         if (*retain)
+         {
+         [(id)pointer retain];
+         }
+         
+         (*pointers)[*count] = pointer;
+         ++*count;
+         /*/
+        
+        nglArrayLock(array);
+
+        if ((*array).count >= (*array).capacity)
+        {
+            nglArrayResize(array);
+        }
+        
+        if ((*array).retainOption)
+        {
+            [(id)pointer retain];
+        }
+        
+        (*array).pointers[(*array).count] = pointer;
+        ++(*array).count;
+
+        nglArrayUnlock(array);
+    }
 }
 
 static unsigned int nglArrayIndexOfPointer(NGLArrayValues *array, void *pointer)
@@ -139,17 +190,20 @@ static unsigned int nglArrayIndexOfPointer(NGLArrayValues *array, void *pointer)
 	 }
 	 }
 	 /*/
-	void **itemPtr = (*array).pointers;
+    nglArrayLock(array);
+    void **itemPtr = (*array).pointers;
 	
 	unsigned int i;
 	for (i = 0; i < (*array).count; ++i)
 	{
 		if (pointer == *itemPtr++)
 		{
+            nglArrayUnlock(array);
 			return i;
 		}
 	}
 	//*/
+    nglArrayUnlock(array);
 	return NGL_NOT_FOUND;
 }
 
@@ -196,6 +250,9 @@ static void nglArrayRemovePointer(NGLArrayValues *array, void *pointer)
 	 *itemPtr++ = item;
 	 }
 	 /*/
+    
+    nglArrayLock(array);
+
 	void **originalPtr = (*array).pointers;
 	void **itemPtr = (*array).pointers;
 	void *item;
@@ -204,7 +261,8 @@ static void nglArrayRemovePointer(NGLArrayValues *array, void *pointer)
 	unsigned int length = (*array).count;
 	for (n = 0; n < length; ++n)
 	{
-		item = *originalPtr++;
+		item = *originalPtr;
+        originalPtr++;
 		
 		if (item == pointer)
 		{
@@ -227,8 +285,12 @@ static void nglArrayRemovePointer(NGLArrayValues *array, void *pointer)
 		}
 		
 		// Pulls the array to preserve the integrity.
-		*itemPtr++ = item;
+		*itemPtr = item;
+        itemPtr++;
 	}
+    
+    nglArrayUnlock(array);
+
 	//*/
 }
 
@@ -262,6 +324,8 @@ static void nglArrayRemovePointerAtIndex(NGLArrayValues *array, unsigned int ind
 	 memmove(*pointers + index, *pointers + index + 1, NGL_SIZE_POINTER * (*count - index));
 	 }
 	 /*/
+    
+    nglArrayLock(array);
 	if (index < (*array).count)
 	{
 		--(*array).count;
@@ -283,6 +347,8 @@ static void nglArrayRemovePointerAtIndex(NGLArrayValues *array, unsigned int ind
 		unsigned int endCount = (*array).count - index;
 		memmove((*array).pointers + index, (*array).pointers + index + 1, NGL_SIZE_POINTER * endCount);
 	}
+    nglArrayUnlock(array);
+
 	//*/
 }
 
@@ -311,6 +377,8 @@ static void nglArrayRemoveAll(NGLArrayValues *array)
 	 *count = 0;
 	 *i = 0;
 	 /*/
+    nglArrayLock(array);
+
 	if ((*array).retainOption)
 	{
 		void **itemPtr = (*array).pointers;
@@ -326,6 +394,8 @@ static void nglArrayRemoveAll(NGLArrayValues *array)
 	(*array).iterator = (*array).pointers;
 	(*array).count = 0;
 	(*array).i = 0;
+    
+    nglArrayUnlock(array);
 	//*/
 }
 
@@ -565,7 +635,17 @@ BOOL nglPointerIsValidToSelector(void *pointer, SEL selector)
 	_values.i = 0;
 	_values.capacity = 0;
 	_values.retainOption = NO;
-	nglArrayResize(&_values);
+
+    // Set up a recursive mutex so code on the same thread can recursively enter.
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&_values.mutex, &attr );
+    _values.mutex_lock_count=0;
+    _values.callstack=nil;
+    _values.callthread = nil;
+
+    nglArrayResize(&_values);
 }
 
 #pragma mark -
@@ -581,7 +661,6 @@ BOOL nglPointerIsValidToSelector(void *pointer, SEL selector)
 
 - (void) addPointerOnce:(void *)pointer
 {
-
 	if (nglArrayIndexOfPointer(&_values, pointer) == NGL_NOT_FOUND)
 	{
 		nglArrayAddPointer(&_values, pointer);
@@ -648,33 +727,68 @@ BOOL nglPointerIsValidToSelector(void *pointer, SEL selector)
 	return _values.count;
 }
 
+- (void) lock
+{
+    nglArrayLock(&_values);
+}
+
+- (void) unlock
+{
+    nglArrayUnlock(&_values);
+}
+
+
 - (NGLArrayValues *) forLoop:(void **)target
 {
+    [self lock];
+
 	// Resets the iterator saving another Obj-C call.
 	_values.i = 0;
 	_values.iterator = _values.pointers;
 	
 	// Sets the first pointer. Avoids BAD_ACCESS to an unknown pointers.
-	*target = (_values.count > 0) ? *_values.iterator++ : NULL;
-	
+	*target = (_values.count > 0) ? *_values.iterator : NULL;
+    
 	// Return the values to the loop.
 	return &_values;
+}
+
+- (BOOL) forCheck {
+    BOOL result = self->_values.i < self->_values.count;
+    if( !result ) {
+        [self unlock]; // last check, unlock.
+    }
+    return result;
 }
 
 - (void *) nextIterator
 {
 	// Loops iterator until it reach the variables count.
-	if (_values.i++ < _values.count)
+	if(_values.i+1 < _values.count)
 	{
-		return *_values.iterator++;
+        _values.i++;
+        _values.iterator++;
+        void *retVal = *_values.iterator;
+        return retVal;
 	}
-	// When iterator reach the variables count, resets iterator.
+	// When iterator reach the variables count, always return NULL
 	else
 	{
-		[self resetIterator];
+        if( _values.i < _values.count ) {
+            _values.i++;            // Declare we're past .count
+            _values.iterator=NULL;  // Terminate iteration.
+        }
+        return NULL;
 	}
-	
-	return NULL;
+}
+
+- (void *) endLoop
+{
+    if( _values.count > 0 ) {
+        [self unlock]; // AH: SKETCHY!!
+    }
+    
+    return NULL;
 }
 
 - (void) resetIterator
@@ -752,6 +866,7 @@ BOOL nglPointerIsValidToSelector(void *pointer, SEL selector)
 {
 	[self removeAll];
 	nglFree(_values.pointers);
+    pthread_mutex_destroy(&_values.mutex);
 	
 	[super dealloc];
 }


### PR DESCRIPTION
Hi DB,  I've folded in a bunch of fixes to get a project up and running in 64bit mode.  Along the way I found and fixed a few race conditions and access contentions around the use of NGLArray and NGLThread, so I've mutex protected specific code regions.

NGLArray mutex locking is re-enterant, so it will safely re-lock multiple times on the same thread.   The NGLThread message dispatch was modified to minimize NGLArray access contention, and this seems to have cleared up a lot of mystery crashes.

It was possible for two parser threads to simultaneously double launch the helper thread, creating two of the same helpers.  So nglThreadGet got some mutex protection to prevent that as well.

Thanks for the amazing 3D engine library, it's an honour to contribute back to it.
